### PR TITLE
#23 Fix mobile imprint headers

### DIFF
--- a/src/app/(header-footer)/imprint/page.tsx
+++ b/src/app/(header-footer)/imprint/page.tsx
@@ -39,7 +39,7 @@ export default function ImprintPage() {
       </div>
 
       <div className='flex flex-col items-center gap-5'>
-        <h1>Kontakt</h1>
+        <h2>Kontakt</h2>
         <p className='text-center'>
           Telefon: +49 (0)89 31908366
           <br />
@@ -48,7 +48,7 @@ export default function ImprintPage() {
       </div>
 
       <div className='flex flex-col items-center gap-5'>
-        <h1>Umsatzsteuer-ID</h1>
+        <h2>Umsatzsteuer-ID</h2>
         <p className='text-center'>
           Umsatzsteuer-Identifikationsnummer gemäß § 27 a Umsatzsteuergesetz:
           <br />
@@ -57,7 +57,9 @@ export default function ImprintPage() {
       </div>
 
       <div className='flex flex-col items-center gap-5'>
-        <h1>EU-Streitschlichtung</h1>
+        <h2 lang='de' className='hyphens-auto'>
+          EU-Streitschlichtung
+        </h2>
         <p className='text-center'>
           Die Europäische Kommission stellt eine Plattform zur
           Online-Streitbeilegung (OS) bereit:{' '}
@@ -68,9 +70,10 @@ export default function ImprintPage() {
         </p>
       </div>
       <div className='flex flex-col items-center gap-5'>
-        <h1 className='text-center'>
-          Verbraucherstreitbeilegung / Universalschlichtungsstelle
-        </h1>
+        <h2 lang='de' className='hyphens-auto text-center'>
+          Verbraucherstreitbeilegung / <br className='hidden lg:inline-flex' />{' '}
+          Universalschlichtungsstelle
+        </h2>
         <p className='text-center'>
           Wir sind nicht bereit oder verpflichtet, an Streitbeilegungsverfahren
           vor einer Verbraucherschlichtungsstelle teilzunehmen.

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -120,6 +120,11 @@
   .h1 {
     @apply font-primary text-3xl font-semibold;
   }
+
+  h2,
+  .h2 {
+    @apply font-primary text-2xl font-semibold;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
# Description & Technical Solution

- reduce text size of headers and break words with hyphen to avoid layout break

# Checklist

# Screenshots
<img src="https://github.com/unit214/website-new/assets/23051372/fbd05704-3c2d-45ba-bcdf-f20aeedd7c4e" width=300/>


# Related issue
- Resolve #23