### PR TITLE
build: fix next build if no posts are present

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "next dev",
     "build": "next build",
-    "start": "next start",
+    "start": "npx serve@latest out",
     "lint": "next lint",
     "lint:fix": "eslint src --fix && yarn format",
     "lint:strict": "eslint --max-warnings=0 src",

--- a/src/app/(header-footer)/blog/[postId]/page.tsx
+++ b/src/app/(header-footer)/blog/[postId]/page.tsx
@@ -21,7 +21,10 @@ type BlogPostProps = {
 export async function generateStaticParams() {
   const posts = await getPosts()
 
-  if (!posts) return []
+  // TODO change to empty array once https://github.com/vercel/next.js/issues/61213 is resolved
+  if (!posts || posts.length === 0) {
+    return [{ postId: 'none' }]
+  }
 
   return posts.map((post) => ({
     postId: post.meta.id,
@@ -46,7 +49,7 @@ export async function generateMetadata({ params: { postId } }: BlogPostProps) {
 export default async function BlogPost({ params: { postId } }: BlogPostProps) {
   const allPosts = await getPosts()
 
-  if (!allPosts) notFound()
+  if (!allPosts || allPosts.length === 0) notFound()
 
   let post: Post | undefined
   let previousPostMeta: Meta | undefined

--- a/src/lib/blog.ts
+++ b/src/lib/blog.ts
@@ -19,10 +19,15 @@ const allBlogPostIds = fs
   })
 
 export async function getPost(postId: string): Promise<Post | undefined> {
-  const fileContent = fs.readFileSync(
-    path.join(process.cwd(), `${BLOG_POST_FOLDER}/${postId}.md`),
-    'utf8',
-  )
+  let fileContent
+  try {
+    fileContent = fs.readFileSync(
+      path.join(process.cwd(), `${BLOG_POST_FOLDER}/${postId}.md`),
+      'utf8',
+    )
+  } catch (err) {
+    return undefined
+  }
 
   const { frontmatter, content } = await compileMDX<{
     title: string


### PR DESCRIPTION
# Description & Technical Solution

- Fix `next build` when no posts are present
- Fix `yarn start` script with `output: export`
