### PR TITLE
Feat: Calendar redirect

### DIFF
--- a/src/app/[calendarRedirect]/page.tsx
+++ b/src/app/[calendarRedirect]/page.tsx
@@ -1,0 +1,45 @@
+import { notFound } from 'next/navigation'
+
+import ClientRedirect from '@/components/ClientRedirect'
+import NextLink from '@/components/NextLink'
+
+import { teamMembers } from '@/constant/teamMembers'
+
+type MeetTeamMemberProps = {
+  params: {
+    calendarRedirect: string
+  }
+}
+export function generateStaticParams() {
+  return teamMembers
+    .map((teamMember) => ({
+      calendarRedirect: teamMember.calendarRedirectSegment,
+    }))
+    .filter((url) => !!url)
+}
+
+export default function MeetTeamMember({
+  params: { calendarRedirect },
+}: MeetTeamMemberProps) {
+  const teamMember = teamMembers.find(
+    (member) => member.calendarRedirectSegment === calendarRedirect,
+  )
+  if (!teamMember || !teamMember.calendarLink) {
+    notFound()
+  } else {
+    return (
+      <>
+        <div className='mt-20 flex justify-center text-lg'>
+          <div>
+            The page you were on is trying to send you to{' '}
+            <NextLink className='text-blue-500' href={teamMember.calendarLink!}>
+              {teamMember.calendarLink!}
+            </NextLink>
+            .
+          </div>
+        </div>
+        <ClientRedirect url={teamMember.calendarLink!} />
+      </>
+    )
+  }
+}

--- a/src/components/ClientRedirect.tsx
+++ b/src/components/ClientRedirect.tsx
@@ -1,0 +1,10 @@
+'use client'
+import { redirect } from 'next/navigation'
+import { useEffect } from 'react'
+
+export default function ClientRedirect({ url }: { url: string }) {
+  useEffect(() => {
+    redirect(url)
+  }, [url])
+  return <></>
+}

--- a/src/components/home/LetsGetInTouch.tsx
+++ b/src/components/home/LetsGetInTouch.tsx
@@ -4,6 +4,7 @@ import { SiGooglecalendar } from 'react-icons/si'
 import NextLink from '@/components/NextLink'
 
 import { contactEmail } from '@/constant/contact'
+import { teamMembers } from '@/constant/teamMembers'
 
 export default function LetsGetInTouch() {
   return (
@@ -19,7 +20,10 @@ export default function LetsGetInTouch() {
       </NextLink>
       <NextLink
         className='flex items-center gap-1 lg:hidden'
-        href='https://calendar.app.google/KicY9pSkoYKqWzZP8'
+        href={
+          teamMembers.find((m) => m.name === 'Tom Graupner')!
+            .calendarRedirectSegment!
+        }
         isExternalLink
       >
         Book a meeting with us! <SiGooglecalendar />

--- a/src/components/home/WhoWeAre.tsx
+++ b/src/components/home/WhoWeAre.tsx
@@ -6,10 +6,7 @@ import { cn } from '@/lib/utils'
 
 import NextLink from '@/components/NextLink'
 
-import KenoLogo from '~/svg/who-we-are-keno.svg'
-import PhilippLogo from '~/svg/who-we-are-philipp.svg'
-import TimoLogo from '~/svg/who-we-are-timo.svg'
-import TomLogo from '~/svg/who-we-are-tom.svg'
+import { teamMembers } from '@/constant/teamMembers'
 
 function ExternalReferences({
   linkedInLink,
@@ -89,61 +86,17 @@ export default function WhoWeAre() {
       <div className='flex w-[430px] flex-col gap-10 lg:w-fit lg:flex-row lg:items-start lg:gap-20'>
         <h1 className='whitespace-nowrap'>Who We Are</h1>
         <div className='flex flex-col gap-10'>
-          <TeamMemberField
-            Logo={TomLogo}
-            name='Tom Graupner'
-            description={
-              <>
-                Co-Founder, Backend Developer
-                <br />
-                and Cloud-Native Specialist
-              </>
-            }
-            linkedInLink='https://www.linkedin.com/in/tom-graupner/'
-            gitHubLink='https://github.com/tgraupne'
-            calendarLink='https://calendar.app.google/KicY9pSkoYKqWzZP8'
-          />
-          <TeamMemberField
-            Logo={KenoLogo}
-            name='Keno Dreßel'
-            description={
-              <>
-                Co-Founder, Full-Stack Engineer
-                <br />
-                and Machine Learning Specialist
-              </>
-            }
-            linkedInLink='https://www.linkedin.com/in/kenodressel/'
-            gitHubLink='https://github.com/kenodressel'
-            calendarLink='https://calendar.app.google/vL9yUjz599Xcdx9q8'
-          />
-          <TeamMemberField
-            Logo={PhilippLogo}
-            name='Philipp Piwowarsky'
-            description={
-              <>
-                Co-Founder, Full-Stack Engineer
-                <br />
-                and Blockchain Specialist
-              </>
-            }
-            linkedInLink='https://www.linkedin.com/in/philipp-piwowarsky/'
-            gitHubLink='https://github.com/thepiwo'
-            calendarLink='https://calendar.app.google/eJDr4qYncBod3xsi7'
-          />
-          <TeamMemberField
-            Logo={TimoLogo}
-            name='Timo Erdelt'
-            description={
-              <>
-                Full-Stack Engineer, Green IT, Functional
-                <br />
-                Programming, User-Centered Design
-              </>
-            }
-            linkedInLink='https://www.linkedin.com/in/timoerdelt/'
-            gitHubLink='https://github.com/tmrdlt'
-          />
+          {teamMembers.map((teamMember, key) => (
+            <TeamMemberField
+              Logo={teamMember.logo}
+              name={teamMember.name}
+              description={teamMember.description}
+              linkedInLink={teamMember.linkedInLink}
+              gitHubLink={teamMember.gitHubLink}
+              calendarLink={teamMember.calendarRedirectSegment}
+              key={key}
+            />
+          ))}
         </div>
       </div>
     </div>

--- a/src/constant/models.ts
+++ b/src/constant/models.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react'
+import { FC, ReactElement, SVGProps } from 'react'
 
 export type Testimonial = {
   source: string
@@ -25,4 +25,14 @@ export type Meta = {
 export type Post = {
   meta: Meta
   content: ReactElement
+}
+
+export type TeamMember = {
+  name: string
+  logo: FC<SVGProps<SVGSVGElement>>
+  description: ReactElement
+  linkedInLink: string
+  gitHubLink: string
+  calendarLink?: string
+  calendarRedirectSegment?: string // local url segment used to redirect to calendar link ({baseUrl}/{calendarRedirectUrl})
 }

--- a/src/constant/teamMembers.tsx
+++ b/src/constant/teamMembers.tsx
@@ -1,0 +1,66 @@
+import KenoLogo from '~/svg/who-we-are-keno.svg'
+import PhilippLogo from '~/svg/who-we-are-philipp.svg'
+import TimoLogo from '~/svg/who-we-are-timo.svg'
+import TomLogo from '~/svg/who-we-are-tom.svg'
+export const teamMembers = [
+  {
+    name: 'Tom Graupner',
+    logo: TomLogo,
+    description: (
+      <>
+        Co-Founder, Backend Developer
+        <br />
+        and Cloud-Native Specialist
+      </>
+    ),
+    linkedInLink: 'https://www.linkedin.com/in/tom-graupner/',
+    gitHubLink: 'https://github.com/tgraupne',
+    calendarLink: 'https://calendar.app.google/KicY9pSkoYKqWzZP8',
+    calendarRedirectSegment: 'meet-tom',
+  },
+  {
+    name: 'Keno Dreßel',
+    logo: KenoLogo,
+    description: (
+      <>
+        Co-Founder, Full-Stack Engineer
+        <br />
+        and Machine Learning Specialist
+      </>
+    ),
+    linkedInLink: 'https://www.linkedin.com/in/kenodressel/',
+    gitHubLink: 'https://github.com/kenodressel',
+    calendarLink: 'https://calendar.app.google/vL9yUjz599Xcdx9q8',
+    calendarRedirectSegment: 'meet-keno',
+  },
+  {
+    name: 'Philipp Piwowarsky',
+    logo: PhilippLogo,
+    description: (
+      <>
+        Co-Founder, Full-Stack Engineer
+        <br />
+        and Blockchain Specialist
+      </>
+    ),
+    linkedInLink: 'https://www.linkedin.com/in/philipp-piwowarsky/',
+    gitHubLink: 'https://github.com/thepiwo',
+    calendarLink: 'https://calendar.app.google/eJDr4qYncBod3xsi7',
+    calendarRedirectSegment: 'meet-philipp',
+  },
+  {
+    name: 'Timo Erdelt',
+    logo: TimoLogo,
+    description: (
+      <>
+        Full-Stack Engineer, Green IT, Functional
+        <br />
+        Programming, User-Centered Design
+      </>
+    ),
+    linkedInLink: 'https://www.linkedin.com/in/timoerdelt/',
+    gitHubLink: 'https://github.com/tmrdlt',
+    calendarLink: undefined,
+    calendarRedirectSegment: undefined,
+  },
+] as const


### PR DESCRIPTION
# Description & Technical Solution

- Added calendar redirect page: `/meet-{name}` will now redirect to the `calendarLink` of a team member, if existent
- Moved team member infos to constants

# Checklist

# Screenshots
