### PR TITLE
feat(blog): updated rendering of blogpost preview image

### DIFF
--- a/src/components/home/techjournal/BlogPostPreview.tsx
+++ b/src/components/home/techjournal/BlogPostPreview.tsx
@@ -15,7 +15,7 @@ export default function BlogPostPreview({ post }: { post: Post }) {
         <NextImage
           alt='preview'
           src={post.meta.previewImage || '/blogposts/preview/default.jpg'}
-          style={{ objectFit: 'cover' }}
+          style={{ objectFit: 'contain' }}
           fill
         />
       </div>


### PR DESCRIPTION
This PR proposes a small change in the way we render preview images of blog posts on the homepage in the Tech Journal section. Instead of cropping preview images, this PR updates the size to always show the full image. This enables us and designers to create preview images which will always be shown in its full beauty.

## This is an example of the old rendering:

<img width="1316" alt="image (1)" src="https://github.com/unit214/website/assets/7671391/ebb772d2-9a9b-48d5-8bda-9f48f99640c5">

## And this is the proposed new solution:
<img width="1337" alt="image" src="https://github.com/unit214/website/assets/7671391/67956b99-9f6a-4747-a80a-90af3adb5319">

