### PR TITLE
feat(blog): adds og preview

### DIFF
--- a/src/app/(header-footer)/blog/[postId]/page.tsx
+++ b/src/app/(header-footer)/blog/[postId]/page.tsx
@@ -11,6 +11,7 @@ import { formatDate } from '@/lib/date'
 
 import NextLink from '@/components/NextLink'
 
+import { siteConfig } from '@/constant/config'
 import { Meta, Post } from '@/constant/models'
 import { teamMembers } from '@/constant/teamMembers'
 
@@ -44,7 +45,30 @@ export async function generateMetadata({ params: { postId } }: BlogPostProps) {
 
   return {
     title: post.meta.title,
-    description: 'Unit 214',
+    description: post.meta.previewText,
+    openGraph: {
+      title: post.meta.title,
+      description: post.meta.previewText,
+      url: `${siteConfig.url}/blog/${post.meta.id}`,
+      type: 'article',
+      images: [
+        {
+          url: `${siteConfig.url}${post.meta.previewImage}`,
+          alt: post.meta.title,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: post.meta.title,
+      description: post.meta.previewText,
+      images: [
+        {
+          url: `${siteConfig.url}${post.meta.previewImage}`,
+          alt: post.meta.title,
+        },
+      ],
+    },
   }
 }
 


### PR DESCRIPTION
# Description & Technical Solution

- adds og preview for blog posts

before: #60 

after:
![image](https://github.com/user-attachments/assets/09d74b56-37ea-45ee-aa9e-f9a8ccc744ab)


# Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] Already rebased against main branch.

# Screenshots

Provide screenshots or videos of the changes made if any.
